### PR TITLE
Change Guzzle constraint to major

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "guzzlehttp/guzzle": "~7.0|~6.0|~5.0|~4.0",
+        "guzzlehttp/guzzle": "^7.0|^6.0|^5.0|^4.0",
         "ext-mbstring": "*",
         "ext-json": "*"
     },


### PR DESCRIPTION
Previously `~` was used, which locked this package to using the specific minor version. So, for example, only Guzzle 7.0 could be used, and not 7.9.