### PR TITLE
add alek13/slack as a replacement for maknz/slack in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,8 @@
             "dev-master": "2.x-dev"
         }
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "replace": {
+        "maknz/slack": "<=1.7.0"
+    }
 }


### PR DESCRIPTION
Hi,

as a developer maintaining a legacy application which uses maknz/slack, I would have loved to know there was a replacement working on newer guzzlehttp/guzzle in a more straight forward fashion, rather than randomly searching in packagist.

Adding a `replace` inside the `composer.json` is enough to let most repositories know there is such alternative package.

Furthermore, this is not invasive or disrespectful for the original project's maintainer as composer replacements are marked from a version so both projects can evolve differently from that version onward (which is not so relevant in this particular case, as the original project is sadly not maintained anymore).

I am not sure if `2.x` is the correct branch to apply the PR to. But it'll probably suit me the most not to wait for a v3 release.

Let me know if I need to change something else.