### PR TITLE
Support Guzzle 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ with [incoming webhooks](https://my.slack.com/services/new/incoming-webhook),
 focused on ease-of-use and elegant syntax.
 
 **supports:** PHP `7.1`, `7.2`, `7.3`, `7.4` or `8.0`, `8.1`, `8.2`, `8.3`, `8.4`  
-**require:** `guzzlehttp/guzzle` any of versions `~7.0|~6.0|~5.0|~4.0`
+**require:** `guzzlehttp/guzzle` any of versions `~8.0|~7.0|~6.0|~5.0|~4.0`
 
 > This is the fork of popular, great, but abandoned package [`maknz/slack`](https://github.com/maknz/slack)
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A simple PHP package for sending messages to [Slack](https://slack.com)
 with [incoming webhooks](https://my.slack.com/services/new/incoming-webhook),
 focused on ease-of-use and elegant syntax.
 
-**supports:** PHP `7.1`, `7.2`, `7.3`, `7.4` or `8.0`, `8.1`, `8.2`, `8.3`, `8.4`  
-**require:** `guzzlehttp/guzzle` any of versions `~8.0|~7.0|~6.0|~5.0|~4.0`
+**supports:** PHP `7.2.5+`, `7.3`, `7.4` or `8.0`, `8.1`, `8.2`, `8.3`, `8.4`<br>
+**require:** `guzzlehttp/guzzle` any of versions `^7.0 || ^8.0`
 
 > This is the fork of popular, great, but abandoned package [`maknz/slack`](https://github.com/maknz/slack)
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "guzzlehttp/guzzle": "~7.0|~6.0|~5.0|~4.0",
+        "guzzlehttp/guzzle": "~8.0|~7.0|~6.0|~5.0|~4.0",
         "ext-mbstring": "*",
         "ext-json": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
-        "guzzlehttp/guzzle": "~8.0|~7.0|~6.0|~5.0|~4.0",
+        "php": "^7.2.5 || ^8.0",
+        "guzzlehttp/guzzle": "^7.0 || ^8.0",
         "ext-mbstring": "*",
         "ext-json": "*"
     },


### PR DESCRIPTION
## Summary

- allow Guzzle 8 while preserving Guzzle 7 support
- drop the legacy Guzzle 4–6 ranges requested in review
- align the package PHP floor with Guzzle 7 at `^7.2.5`, remove the PHP 7.1 Travis lane, and synchronize the README
- leave source and tests unchanged because the existing HTTP integration is compatible

Closes #88.

## Validation

Validated on PHP 8.5.9 with Composer 2.10.2.

### Guzzle 8

```sh
composer update guzzlehttp/guzzle phpunit/phpunit \
  --with 'guzzlehttp/guzzle:^8.0' \
  --with 'phpunit/phpunit:^9.6' \
  --with-all-dependencies --no-interaction
composer validate --strict --no-check-publish
composer check-platform-reqs
vendor/bin/phpunit
composer audit --locked --no-interaction
```

- resolved `guzzlehttp/guzzle 8.0.1`, `guzzlehttp/promises 3.0.0`, and `guzzlehttp/psr7 3.0.0`
- PHPUnit: 206 tests, 386 assertions
- Composer validation, platform checks, and advisory audit passed
- a real `GuzzleHttp\Client` + `MockHandler` smoke traversed `Maknz\Slack\Client::send()` and verified the POST URI, JSON content type, and payload

### Guzzle 7

```sh
composer update guzzlehttp/guzzle phpunit/phpunit \
  --with 'guzzlehttp/guzzle:^7.0' \
  --with 'phpunit/phpunit:^9.6' \
  --with-all-dependencies --no-interaction
composer validate --strict --no-check-publish
composer check-platform-reqs
vendor/bin/phpunit
composer audit --locked --no-interaction
```

- resolved `guzzlehttp/guzzle 7.15.2`
- PHPUnit: 206 tests, 386 assertions
- Composer validation, platform checks, advisory audit, and the same real-client smoke passed
- exact metadata checks confirm Guzzle 6 and PHP 7.1 are no longer accepted

The unconstrained development requirement `phpunit/phpunit >=7.5` selects PHPUnit 13 on PHP 8.5, which exposes a pre-existing legacy `@dataProvider` metadata failure. The compatibility runs therefore use PHPUnit 9.6, matching this repository's PHPUnit 9 configuration schema; that run retains the existing deprecated XML schema and empty base `TestCase` warnings.
